### PR TITLE
Enable agent deregister on termination notification

### DIFF
--- a/Managed-Oxygen/Install-ADOAgent.ps1
+++ b/Managed-Oxygen/Install-ADOAgent.ps1
@@ -7,7 +7,17 @@ param (
     [string][Parameter(Mandatory=$true)]$password
 )
 
-mkdir -force "c:\tmp"
+# Get agent
+New-Item -Type Directory -Force "c:\tmp"
 Invoke-WebRequest -Uri "https://vstsagentpackage.azureedge.net/agent/$version/vsts-agent-win-x64-$version.zip" -OutFile "c:\tmp\agent.zip" -UseBasicParsing
 Expand-Archive -Path "c:\tmp\agent.zip" -DestinationPath "c:\agent"
+Remove-Item -Path "c:\tmp\agent.zip"
+
+# Configure agent
 c:\agent\config --unattended --url $url --pool $pool --agent $env:computername --auth pat --token $pat --runAsService --windowsLogonAccount $agent\$username --windowsLogonPassword $password --replace
+
+# Configure agent termination
+$path = Join-Path $PSScriptRoot "Uninstall-ADOAgent.ps1"
+$action = New-ScheduledTaskAction -Execute 'Powershell.exe' -Argument "-NoProfile -File $path $(ConvertTo-SecureString -String $pat -AsPlainText)"
+$trigger = New-ScheduledTaskTrigger -Once -RepetitionInterval (New-TimeSpan -Minutes 1) -at (get-date)
+Register-ScheduledTask -User System -Action $action -Trigger $trigger -TaskName "Watchdog" -Description "Watch for VM termination events to deregister nodes from Azure DevOps"

--- a/Managed-Oxygen/Uninstall-ADOAgent.ps1
+++ b/Managed-Oxygen/Uninstall-ADOAgent.ps1
@@ -1,0 +1,19 @@
+param (
+    [System.Security.SecureString][Parameter(Mandatory=$true)]$pat,
+)
+
+$events = Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -Uri "http://169.254.169.254/metadata/scheduledevents?api-version=2020-07-01" | Select-Object -ExpandProperty events
+$instance_name = Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET  -Uri "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01" | Select-Object -ExpandProperty Name
+
+foreach($event in $events){
+
+    if($event.EventType -eq "Terminate" -and $instance_name -in $event.Resources){
+        # VM is scheduled to shutdown. Uninstall runtime to deregister this node
+        c:\agent\config remove --unattended --auth pat --token (ConvertFrom-SecureString -AsPlainText $pat)
+
+        # Acknowledge event to expedite shutdown
+        $id = $event.EventId
+        Invoke-RestMethod -Headers @{"Metadata" = "true"} -Method POST -body "{""StartRequests"": [{""EventId"": ""$id""}]}" -Uri http://169.254.169.254/metadata/scheduledevents?api-version=2020-07-01
+    }
+
+}


### PR DESCRIPTION
This PR changes the ADO agent installation script by introducing a scheduled task that checks for VM termination events. When a termination event is received the script deregisters the agent from the Azure Devops organization.